### PR TITLE
Bugfix time error

### DIFF
--- a/src/actinet/models.py
+++ b/src/actinet/models.py
@@ -159,7 +159,7 @@ class ActivityClassifier:
         X, T = make_windows(
             data,
             self.window_sec,
-            self.window_sec * sample_freq,
+            int(self.window_sec * sample_freq),
             return_index=True,
             verbose=self.verbose,
         )

--- a/src/actinet/models.py
+++ b/src/actinet/models.py
@@ -155,7 +155,7 @@ class ActivityClassifier:
         return self
 
     def predict_from_frame(self, data, sample_freq, hmm_smothing=True):
-        sample_freq = sample_freq or infer_freq(data.index).total_seconds()
+        sample_freq = sample_freq or 1 / (infer_freq(data.index).total_seconds())
         X, T = make_windows(
             data,
             self.window_sec,

--- a/src/actinet/models.py
+++ b/src/actinet/models.py
@@ -155,7 +155,7 @@ class ActivityClassifier:
         return self
 
     def predict_from_frame(self, data, sample_freq, hmm_smothing=True):
-        sample_freq = sample_freq or infer_freq(data.index)
+        sample_freq = sample_freq or infer_freq(data.index).total_seconds()
         X, T = make_windows(
             data,
             self.window_sec,


### PR DESCRIPTION
#3 The infer_freq function returns timedelta, creating an error when comparing to int.

To fix this:
1. Convert to frequency in Hz
2. Ensure window length input to make_windows is int