### PR TITLE
Improve confusion matrices

### DIFF
--- a/EvaluateModel.ipynb
+++ b/EvaluateModel.ipynb
@@ -176,6 +176,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fold_pid_df = pd.DataFrame([{'Fold': fold+1, \"Test Participant IDs\": \", \".join(sorted(set(group)))} for fold, group in results_actinet[\"group\"].items()]).set_index(\"Fold\")\n",
+    "fold_pid_df.to_csv(\"outputs/actinet_vs_bbaa/fold_pids.csv\")\n",
+    "fold_pid_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "data = {\n",
     "    'accelerometer': {'y': np.hstack(results_bbaa[\"Y_true\"]), \n",
     "                      'y_pred': np.hstack(results_bbaa[\"Y_pred\"]), \n",
@@ -320,9 +331,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "generate_confusion_matrices(results_df, save_path=\"outputs/actinet_vs_bbaa/full_population.pdf\")\n",
-    "generate_confusion_matrices(results_df, group_by=\"Sex\", save_path=\"outputs/actinet_vs_bbaa/by_sex.pdf\")\n",
-    "generate_confusion_matrices(results_df, group_by=\"Age Band\", save_path=\"outputs/actinet_vs_bbaa/by_age.pdf\")"
+    "generate_confusion_matrices(results_df, save_path=\"outputs/actinet_vs_bbaa/full_population.pdf\", fontsize=18)\n",
+    "generate_confusion_matrices(results_df, group_by=\"Sex\", save_path=\"outputs/actinet_vs_bbaa/by_sex.pdf\", fontsize=18)\n",
+    "generate_confusion_matrices(results_df, group_by=\"Age Band\", save_path=\"outputs/actinet_vs_bbaa/by_age.pdf\", fontsize=18)"
    ]
   },
   {


### PR DESCRIPTION
Improve confusion matrices:
* Be set in order: sleep, sedentary, light then MVPA
* Report both proportion and count
* Report testing PIDs for each cross validation fold
