### PR TITLE
Train classifier with different epoch lengths in jupyter

### DIFF
--- a/TrainModel.ipynb
+++ b/TrainModel.ipynb
@@ -121,6 +121,7 @@
     "    labels = np.unique(Y),\n",
     "    batch_size=1000,\n",
     "    device=\"cuda:0\",\n",
+    "    window_sec=WINSEC,\n",
     "    verbose=True\n",
     ")\n",
     "\n",
@@ -171,7 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classifier.fit(X, Y, pid, T, f\"models/c24_rw_{datetime.now().strftime('%Y%m%d')}.pt\", n_splits=1)"
+    "classifier.fit(X, Y, pid, T, f\"models/c24_rw_{WINSEC}s_{datetime.now().strftime('%Y%m%d')}.pt\", n_splits=1)"
    ]
   },
   {
@@ -187,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classifier_file_name = f\"models/ssl_ukb_c24_rw_{datetime.now().strftime('%Y%m%d')}.joblib.lzma\""
+    "classifier_file_name = f\"models/ssl_ukb_c24_rw_{WINSEC}s_{datetime.now().strftime('%Y%m%d')}.joblib.lzma\""
    ]
   },
   {

--- a/src/actinet/prepare.py
+++ b/src/actinet/prepare.py
@@ -1,3 +1,4 @@
+import json
 import numpy as np
 import pandas as pd
 import os
@@ -199,12 +200,25 @@ def load_all_and_make_windows(
         out_path = os.path.join(
             out_dir, f"prepared/downsampling_{downsampling_method}_lowpass_{lowpass_hz}"
         )
+
+        info = {
+            "sample_rate": sample_rate,
+            "winsec": winsec,
+            "resample_rate": resample_rate,
+            "lowpass_hz": lowpass_hz,
+            "downsampling_method": downsampling_method,
+            "anno_label": anno_label,
+        }
+
         # Save arrays for future use
         os.makedirs(out_path, exist_ok=True)
         np.save(f"{out_path}/X.npy", X)
         np.save(f"{out_path}/Y.npy", Y)
         np.save(f"{out_path}/T.npy", T)
         np.save(f"{out_path}/pid.npy", P)
+
+        with open(f"{out_path}/info.json", "w") as f:
+            json.dump(info, f, indent=4)
 
     return X, Y, T, P
 


### PR DESCRIPTION
Allow for training of classifiers with different epoch lengths in jupyter notebooks


Note: This does not implement the deployment of these different epoch length models, just for locally training these model.