### PR TITLE
Ignore transition gaps

### DIFF
--- a/TrainModel.ipynb
+++ b/TrainModel.ipynb
@@ -172,7 +172,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "classifier.fit(X, Y, pid, T, f\"models/c24_rw_{WINSEC}s_{datetime.now().strftime('%Y%m%d')}.pt\", n_splits=1)"
+    "classifier_save_path = f\"models/c24_rw_{WINSEC}s_{datetime.now().strftime('%Y%m%d')}.pt\"\n",
+    "classifier.fit(X, Y, pid, T, True, classifier_save_path, n_splits=1)"
    ]
   },
   {
@@ -258,6 +259,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note ordering is sleep, sedentary, light, MVPA\n",
+    "loaded_classifier.hmm.display(precision=3)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -299,6 +310,13 @@
    "source": [
     "p = plotTimeSeries(y)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/src/actinet/evaluate.py
+++ b/src/actinet/evaluate.py
@@ -137,18 +137,20 @@ def evaluate_models(
             y_train_actinet,
             groups_train_actinet,
             t_train_actinet,
+            True,
             weights_path.format(fold),
             n_splits=5,
         )
+
         y_pred_actinet = actinet_classifier.predict(
             X_test_actinet, t_test_actinet, True, sleep_tol, remove_naps
         ).astype(int)
 
-        # Analysis of accelerometer random forest model
         rf_classifier.fit(
             X_train_rf,
             y_train_rf,
             t_train_rf,
+            True
         )
 
         y_pred_rf = rf_classifier.predict(X_test_rf, t_test_rf, True, sleep_tol, remove_naps)

--- a/src/actinet/hmm.py
+++ b/src/actinet/hmm.py
@@ -166,6 +166,15 @@ class HMM:
         self.transition = d["transition"]
         self.labels = d["labels"]
 
+    def display(self, precision=3):
+        """
+        Print the model parameters in a readable format.
+
+        :param precision: Number of decimal places to print
+        :type precision: int
+        """
+        pretty_hmm_params(self, precision=precision)
+
 
 def check_for_time_values_error(Y, T, interval):
     # If truthy, T must be the same length as Y, and interval must also be truthy
@@ -226,3 +235,43 @@ def calculate_transition_matrix(Y, t=None, interval=None):
         raise Exception("No transitions found in data")
 
     return trans_mat
+
+
+def print_array(arr, precision=3):
+    """Prints all elements of a NumPy array to N decimal places."""
+    arr = np.array(arr)
+    with np.printoptions(precision=precision, suppress=True):
+        print(arr)
+
+
+def reorder_matrix(data, index_order):
+    """Reorder a 1D or 2D square array"""
+    arr = np.array(data)
+
+    if arr.ndim == 1:
+        return arr[index_order]
+    
+    elif arr.ndim == 2:
+        if arr.shape[0] != arr.shape[1]:
+            raise ValueError("2D input must be a square matrix.")
+        # Reorder rows and columns using the same index order
+        return arr[index_order][:, index_order]
+    
+    else:
+        raise ValueError("Input must be a 1D or 2D array.")
+
+
+def pretty_hmm_params(hmm: HMM, index_order=[3, 2, 0, 1], precision=3):
+    """Print the HMM parameters in a readable format, reordering them according to the provided index order."""
+
+    print("Prior:")
+    prior = reorder_matrix(hmm.prior, index_order)
+    print_array(prior, precision)
+
+    print("\nEmission:")
+    emission = reorder_matrix(hmm.emission, index_order)
+    print_array(emission, precision)
+
+    print("\nTransition:")
+    transition = reorder_matrix(hmm.transition, index_order)
+    print_array(transition, precision)


### PR DESCRIPTION
Add option to ignore transition gaps when fitting hmm.
By default, it will now do this.

Note: we have not yet updated the deployment model to use this. 