### PR TITLE
Update docs to better explain cache classifier

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -118,6 +118,8 @@ Option 1: Cache them while online::
 
     actinet --cache-classifier
 
+Note: this will only download the classifier and model files, and will not run the ActiNet model.
+
 Option 2: Manually download from the `ssl-wearables repository <https://github.com/OxWearables/ssl-wearables>`_ and specify paths::
 
     actinet sample.cwa -c /path/to/classifier.joblib.lzma -m /path/to/ssl-wearables

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -118,7 +118,7 @@ Option 1: Cache them while online::
 
     actinet --cache-classifier
 
-Note: this will only download the classifier and model files, and will not run the ActiNet model.
+Note: this will only download the classifier and model files, and prevent the ActiNet classification model from running.
 
 Option 2: Manually download from the `ssl-wearables repository <https://github.com/OxWearables/ssl-wearables>`_ and specify paths::
 

--- a/src/actinet/actinet.py
+++ b/src/actinet/actinet.py
@@ -168,7 +168,7 @@ def main():
     parser.add_argument(
         "--cache-classifier",
         action="store_true",
-        help="Download and cache classifier file and model modules for offline usage only. This will not run the model.",
+        help="Download and cache classifier file and model modules for offline usage. This will not run the ActiNet classification model.",
     )
     parser.add_argument(
         "--model-repo-path", "-m", help="Enter repository of ssl model", default=None

--- a/src/actinet/actinet.py
+++ b/src/actinet/actinet.py
@@ -168,7 +168,7 @@ def main():
     parser.add_argument(
         "--cache-classifier",
         action="store_true",
-        help="Download and cache classifier file and model modules for offline usage. This will not run the ActiNet classification model.",
+        help="Download and cache classifier file and model modules for offline usage. This will cause the ActiNet classification model to not run.",
     )
     parser.add_argument(
         "--model-repo-path", "-m", help="Enter repository of ssl model", default=None

--- a/src/actinet/actinet.py
+++ b/src/actinet/actinet.py
@@ -168,7 +168,7 @@ def main():
     parser.add_argument(
         "--cache-classifier",
         action="store_true",
-        help="Download and cache classifier file and model modules for offline usage",
+        help="Download and cache classifier file and model modules for offline usage only. This will not run the model.",
     )
     parser.add_argument(
         "--model-repo-path", "-m", help="Enter repository of ssl model", default=None


### PR DESCRIPTION
Given issue raised: #49, we have updated the docs to better explain the use of cache-classifier.
Critically, it is expected behaviour that specifying this flag will download the classifier code and model weights.
It will not run the ActiNet model.