### PR TITLE
Retain test-set timestamps in cross-validation fold results

### DIFF
--- a/PR_SUMMARY.md
+++ b/PR_SUMMARY.md
@@ -1,0 +1,8 @@
+# Retain test-set timestamps in cross-validation fold results
+
+Cross-validation fold results now carry the timestamps of the test windows, letting downstream analysis align predictions to time.
+
+## Files Changed
+**`src/actinet/evaluate.py`**
+- Add a `"time"` field to each per-fold result dictionary for both the ActiNet and random forest evaluations, reusing the already-computed per-fold test timestamps.
+- When timestamps are unavailable, store a per-window sequence of `None`s matching the number of predictions instead of a scalar `None`, so every fold's fields stay uniform for downstream concatenation.

--- a/src/actinet/evaluate.py
+++ b/src/actinet/evaluate.py
@@ -174,6 +174,11 @@ def evaluate_models(
             {
                 "fold": [fold] * len(y_pred_actinet),
                 "group": groups_test_actinet,
+                "time": (
+                    t_test_actinet
+                    if t_test_actinet is not None
+                    else [None] * len(y_pred_actinet)
+                ),
                 "Y_pred": le.inverse_transform(y_pred_actinet),
                 "Y_true": le.inverse_transform(y_test_actinet),
             }
@@ -182,6 +187,9 @@ def evaluate_models(
             {
                 "fold": [fold] * len(y_pred_rf),
                 "group": groups_test_rf,
+                "time": (
+                    t_test_rf if t_test_rf is not None else [None] * len(y_pred_rf)
+                ),
                 "Y_pred": le.inverse_transform(y_pred_rf),
                 "Y_true": le.inverse_transform(y_test_rf),
             }


### PR DESCRIPTION

Cross-validation fold results now carry the timestamps of the test windows, letting downstream analysis align predictions to time.

## Files Changed
**`src/actinet/evaluate.py`**
- Add a `"time"` field to each per-fold result dictionary for both the ActiNet and random forest evaluations, reusing the already-computed per-fold test timestamps.
- When timestamps are unavailable, store a per-window sequence of `None`s matching the number of predictions instead of a scalar `None`, so every fold's fields stay uniform for downstream concatenation.